### PR TITLE
Debug type error in crypto helper

### DIFF
--- a/crypto_helper.py
+++ b/crypto_helper.py
@@ -1,5 +1,6 @@
 import os, hmac, hashlib, requests, brotli, zlib, base64
 from datetime import datetime, timezone, timedelta
+from typing import Union, Optional
 from Crypto.Cipher import AES
 from Crypto.Util.Padding import pad
 
@@ -24,7 +25,7 @@ def b64(data: bytes, urlsafe: bool) -> str:
     return enc(data).decode("ascii")
 
 
-def build_encrypted_field(iv_hex16: str | None = None, urlsafe_b64: bool = False) -> str:
+def build_encrypted_field(iv_hex16: Optional[str] = None, urlsafe_b64: bool = False) -> str:
     key = AES_KEY_ASCII.encode("ascii")
     iv_hex = iv_hex16 or random_iv_hex16()
     iv = iv_hex.encode("ascii") 


### PR DESCRIPTION
Update type annotation in `crypto_helper.py` to use `Optional[str]` to fix `TypeError` with union types.

---
<a href="https://cursor.com/background-agent?bcId=bc-87c1f393-39ff-43cb-bb01-0060f60e8d02">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-87c1f393-39ff-43cb-bb01-0060f60e8d02">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

